### PR TITLE
Add request batching for group/area actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+.pytest_cache/

--- a/custom_components/grenton_objects/__init__.py
+++ b/custom_components/grenton_objects/__init__.py
@@ -10,7 +10,7 @@ Repository: https://github.com/jnalepka/grenton-objects-home-assistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.typing import ConfigType
-from .const import DOMAIN
+from .const import DOMAIN, CONF_API_ENDPOINT
 from homeassistant.exceptions import ServiceValidationError
 import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
@@ -231,6 +231,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     config_entry.async_on_unload(
         config_entry.add_update_listener(async_update_options)
     )
+
     device = config_entry.data
     platform = device["device_type"]
     if platform:
@@ -241,5 +242,20 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     device_type = config_entry.data.get("device_type")
     if device_type:
         unload_ok = await hass.config_entries.async_unload_platforms(config_entry, [device_type])
+        # Remove cached API client if endpoint is no longer referenced
+        if unload_ok:
+            api_endpoint = config_entry.data.get(CONF_API_ENDPOINT)
+            if api_endpoint:
+                remaining = hass.config_entries.async_entries(DOMAIN)
+                still_used = any(
+                    entry.entry_id != config_entry.entry_id
+                    and entry.data.get(CONF_API_ENDPOINT) == api_endpoint
+                    for entry in remaining
+                )
+                if not still_used:
+                    clients = hass.data.get(DOMAIN, {}).get("clients", {})
+                    client = clients.pop(api_endpoint, None)
+                    if client:
+                        client.close()
         return unload_ok
     return False

--- a/custom_components/grenton_objects/api.py
+++ b/custom_components/grenton_objects/api.py
@@ -1,0 +1,202 @@
+"""
+==================================================
+Grenton API Client - Centralized HTTP communication layer
+with shared session and optional request batching.
+
+Repository: https://github.com/jnalepka/grenton-objects-home-assistant
+==================================================
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+
+_LOGGER = logging.getLogger(__name__)
+
+# Default: single event-loop tick (asyncio.sleep(0)). Catches concurrent calls
+# from HA group actions with zero perceptible delay for single commands.
+DEFAULT_BATCH_WINDOW = 0.0
+
+
+class GrentonApiError(Exception):
+    """Normalized exception for non-aiohttp errors surfaced by the API client."""
+
+
+class GrentonApiClient:
+    """Centralized HTTP client for communicating with the Grenton HTTP Gate.
+
+    Features:
+    - Shared aiohttp.ClientSession (connection reuse, keepalive)
+    - Command batching: collects commands within a configurable time window
+      and merges them into a single HTTP request.
+
+    Batch window behavior:
+    - 0 (default): waits one event-loop tick (asyncio.sleep(0)). Only truly
+      concurrent calls (e.g. HA group "turn off all lights") get batched.
+      Single commands fire instantly with no perceptible delay.
+    - >0: waits the specified seconds, collecting staggered commands.
+
+    The user configures batch_window per integration entry. Entities sharing
+    the same configuration/endpoint are batched together.
+    """
+
+    def __init__(self, endpoint: str, session: aiohttp.ClientSession, batch_window: float = DEFAULT_BATCH_WINDOW) -> None:
+        self._endpoint = endpoint
+        self._session = session
+        self._batch_window = batch_window
+
+        # Batching state
+        self._pending_commands: list[tuple[str, asyncio.Future]] = []
+        self._batch_lock = asyncio.Lock()
+        self._batch_task: asyncio.Task | None = None
+
+    @property
+    def endpoint(self) -> str:
+        return self._endpoint
+
+    @property
+    def batch_window(self) -> float:
+        return self._batch_window
+
+    def _get_session(self) -> aiohttp.ClientSession:
+        return self._session
+
+    # ─── Public API ───────────────────────────────────────────────────────
+
+    async def send_command(self, command: dict[str, str]) -> dict[str, Any]:
+        """Send a command (POST) to the Grenton Gate.
+
+        The command is queued and merged with other commands arriving within
+        the batch window. With the default window of 0 (one event-loop tick),
+        only truly concurrent calls (e.g. HA group actions) are batched —
+        single commands fire with no perceptible delay.
+        """
+        futures: list[asyncio.Future] = []
+        async with self._batch_lock:
+            loop = asyncio.get_running_loop()
+            for key, value in command.items():
+                future: asyncio.Future = loop.create_future()
+                self._pending_commands.append((value, future))
+                futures.append(future)
+
+            if self._batch_task is None or self._batch_task.done():
+                self._batch_task = asyncio.create_task(self._flush_batch())
+
+        # Wait for the batch to be sent and return the merged response
+        results = await asyncio.gather(*futures)
+        # Reconstruct a response dict matching original keys
+        response = {}
+        for key, result in zip(command.keys(), results):
+            response[key] = result
+        return response
+
+    async def get_status(self, query: dict[str, str]) -> dict[str, Any]:
+        """Send a status query (GET) to the Grenton Gate.
+
+        Status queries are not batched (each entity needs its own response
+        at its own polling interval), but they reuse the shared session.
+        """
+        session = self._get_session()
+        try:
+            async with session.get(self._endpoint, json=query) as response:
+                response.raise_for_status()
+                return await response.json()
+        except aiohttp.ClientError:
+            raise
+        except Exception as ex:
+            raise GrentonApiError(str(ex)) from ex
+
+    def close(self) -> None:
+        """Cancel any in-flight batch task and fail pending futures.
+
+        Called during unload to ensure no background work outlives the entry.
+        """
+        if self._batch_task and not self._batch_task.done():
+            self._batch_task.cancel()
+        for _, future in self._pending_commands:
+            if not future.done():
+                future.cancel()
+        self._pending_commands.clear()
+
+    # ─── Internal ─────────────────────────────────────────────────────────
+
+    async def _flush_batch(self) -> None:
+        """Wait for the batch window, then send all pending commands in one request.
+
+        Drains in a loop to avoid a race where commands enqueued after the
+        copy+clear but before the task completes would never be flushed.
+        Re-applies the batch window before each cycle so late arrivals coalesce.
+        """
+        while True:
+            await asyncio.sleep(self._batch_window)
+
+            async with self._batch_lock:
+                pending = self._pending_commands[:]
+                self._pending_commands.clear()
+
+            if not pending:
+                # Re-check under lock to avoid lost-wakeup: a command may have
+                # been enqueued after clear but before we reach this point, and
+                # the enqueuer saw _batch_task as still running.
+                async with self._batch_lock:
+                    if self._pending_commands:
+                        continue
+                return
+
+            # Build merged payload with numbered command keys
+            payload: dict[str, str] = {}
+            for i, (cmd_value, _) in enumerate(pending):
+                key = "command" if i == 0 else f"command_{i + 1}"
+                payload[key] = cmd_value
+
+            # Send the single merged request
+            try:
+                session = self._get_session()
+                async with session.post(self._endpoint, json=payload) as response:
+                    response.raise_for_status()
+                    data = await response.json()
+
+                # Resolve all futures - the Grenton script returns results keyed
+                # the same way we sent them
+                for i, (_, future) in enumerate(pending):
+                    key = "command" if i == 0 else f"command_{i + 1}"
+                    result = data.get(key, data.get("g_status", "OK"))
+                    if not future.done():
+                        future.set_result(result)
+
+            except asyncio.CancelledError:
+                for _, future in pending:
+                    if not future.done():
+                        future.cancel()
+                raise
+            except Exception as ex:
+                # On failure, reject all futures with a normalized exception
+                wrapped = GrentonApiError(str(ex)) if not isinstance(ex, aiohttp.ClientError) else ex
+                for _, future in pending:
+                    if not future.done():
+                        future.set_exception(wrapped)
+
+
+def get_api_client(hass, endpoint: str, batch_window: float = DEFAULT_BATCH_WINDOW) -> GrentonApiClient:
+    """Get or create a shared GrentonApiClient for the given endpoint.
+
+    If a client already exists for this endpoint, returns the existing one.
+    Uses Home Assistant's shared aiohttp session for proper connection management.
+    """
+    from .const import DOMAIN
+    from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {"entities": {}, "clients": {}}
+
+    if "clients" not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]["clients"] = {}
+
+    clients = hass.data[DOMAIN]["clients"]
+    if endpoint not in clients:
+        session = async_get_clientsession(hass)
+        clients[endpoint] = GrentonApiClient(endpoint, session, batch_window=batch_window)
+
+    return clients[endpoint]

--- a/custom_components/grenton_objects/binary_sensor.py
+++ b/custom_components/grenton_objects/binary_sensor.py
@@ -17,6 +17,8 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN
 )
+from .api import get_api_client, GrentonApiError
+from .mixins import GrentonPollingMixin
 import logging
 import voluptuous as vol
 from homeassistant.components.binary_sensor import (
@@ -24,8 +26,6 @@ from homeassistant.components.binary_sensor import (
     PLATFORM_SCHEMA
 )
 from homeassistant.const import (STATE_ON, STATE_OFF)
-from datetime import timedelta
-from homeassistant.helpers.event import async_track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +42,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     auto_update = config_entry.options.get(CONF_AUTO_UPDATE, config_entry.data.get(CONF_AUTO_UPDATE, True))
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
 
-    entity = GrentonBinarySensor(api_endpoint, grenton_id, object_name, auto_update, update_interval)
+    api_client = get_api_client(hass, api_endpoint)
+    entity = GrentonBinarySensor(api_endpoint, grenton_id, object_name, auto_update, update_interval, api_client)
     async_add_entities([entity], True)
     
     if DOMAIN not in hass.data:
@@ -50,8 +51,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     hass.data[DOMAIN]["entities"][entity.entity_id] = entity
 
-class GrentonBinarySensor(BinarySensorEntity):
-    def __init__(self, api_endpoint, grenton_id, object_name, auto_update, update_interval):
+class GrentonBinarySensor(GrentonPollingMixin, BinarySensorEntity):
+    def __init__(self, api_endpoint, grenton_id, object_name, auto_update, update_interval, api_client):
         self._api_endpoint = api_endpoint
         self._grenton_id = grenton_id
         self._object_name = object_name
@@ -61,21 +62,7 @@ class GrentonBinarySensor(BinarySensorEntity):
         self._update_interval = update_interval
         self._unsub_interval = None
         self._initialized = False
-
-    async def async_added_to_hass(self):
-        self._initialized = True
-        if self._auto_update:
-            self._unsub_interval = async_track_time_interval(
-                self.hass, self._update_callback, timedelta(seconds=self._update_interval)
-            )
-            await self.async_update()
-
-    async def async_will_remove_from_hass(self):
-        if self._unsub_interval:
-            self._unsub_interval()
-
-    async def _update_callback(self, now):
-        await self.async_update()
+        self._api_client = api_client
 
     async def async_force_state(self, state: int):
         self._state = STATE_ON if state == 1 else STATE_OFF
@@ -104,12 +91,9 @@ class GrentonBinarySensor(BinarySensorEntity):
         try:
             grenton_id_part_0, grenton_id_part_1 = self._grenton_id.split('->')
             command = {"status": f"return {grenton_id_part_0}:execute(0, '{grenton_id_part_1}:get(0)')"}
-            async with aiohttp.ClientSession() as session:
-                async with session.get(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-                    self._state = STATE_OFF if data.get("status") == 0 else STATE_ON
-                    self.async_write_ha_state()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to update the binary sensor state: {ex}")
+            data = await self._api_client.get_status(command)
+            self._state = STATE_OFF if data.get("status") == 0 else STATE_ON
+            self.async_write_ha_state()
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to update the binary sensor state: %s", ex)
             self._state = None

--- a/custom_components/grenton_objects/button.py
+++ b/custom_components/grenton_objects/button.py
@@ -11,12 +11,12 @@ import aiohttp
 import logging
 import voluptuous as vol
 from homeassistant.components.button import ButtonEntity
-from homeassistant.helpers.entity import Entity
 from .const import (
     CONF_API_ENDPOINT,
     CONF_GRENTON_ID,
     CONF_OBJECT_NAME
 )
+from .api import get_api_client, GrentonApiError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,15 +31,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     grenton_id = config_entry.data.get(CONF_GRENTON_ID)
     object_name = config_entry.data.get(CONF_OBJECT_NAME)
     
-    async_add_entities([GrentonScript(api_endpoint, grenton_id, object_name)], True)
+    api_client = get_api_client(hass, api_endpoint)
+    async_add_entities([GrentonScript(api_endpoint, grenton_id, object_name, api_client)], True)
     
     
 class GrentonScript(ButtonEntity):
-    def __init__(self, api_endpoint, grenton_id, object_name):
+    def __init__(self, api_endpoint, grenton_id, object_name, api_client):
         self._object_name = object_name
         self._api_endpoint = api_endpoint
         self._grenton_id = grenton_id
         self._unique_id = f"grenton_{grenton_id.split('->')[1] if '->' in grenton_id else grenton_id}"
+        self._api_client = api_client
         
 
     @property
@@ -49,7 +51,7 @@ class GrentonScript(ButtonEntity):
     @property
     def unique_id(self):
         return self._unique_id
-    
+ 
     async def async_press(self):
         try:
             if '->' in self._grenton_id:
@@ -61,9 +63,7 @@ class GrentonScript(ButtonEntity):
                 command = {
                     "command": f"{self._grenton_id}(nil)"
                 }
-            async with aiohttp.ClientSession() as session:
-                async with session.post(self._api_endpoint, json=command) as response:
-                    response.raise_for_status()
-                    _LOGGER.info(f"Script {self._object_name} executed successfully (Grenton).")
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to execute script {self._object_name}: {ex}")
+            await self._api_client.send_command(command)
+            _LOGGER.info("Script %s executed successfully (Grenton).", self._object_name)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to execute script %s: %s", self._object_name, ex)

--- a/custom_components/grenton_objects/climate.py
+++ b/custom_components/grenton_objects/climate.py
@@ -12,11 +12,12 @@ from .const import (
     CONF_API_ENDPOINT,
     CONF_GRENTON_ID,
     CONF_OBJECT_NAME,
-    CONF_AUTO_UPDATE,
     CONF_UPDATE_INTERVAL, 
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN
 )
+from .api import get_api_client, GrentonApiError
+from .mixins import GrentonPollingMixin, is_within_debounce
 import logging
 import voluptuous as vol
 from homeassistant.components.climate import (
@@ -26,8 +27,6 @@ from homeassistant.components.climate import (
     ClimateEntityFeature
 )
 from homeassistant.const import UnitOfTemperature
-from datetime import timedelta
-from homeassistant.helpers.event import async_track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,7 +43,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     auto_update = True
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
 
-    entity = GrentonClimate(api_endpoint, grenton_id, object_name, auto_update, update_interval)
+    api_client = get_api_client(hass, api_endpoint)
+    entity = GrentonClimate(api_endpoint, grenton_id, object_name, auto_update, update_interval, api_client)
     async_add_entities([entity], True)
 
     if DOMAIN not in hass.data:
@@ -52,10 +52,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     hass.data[DOMAIN]["entities"][entity.entity_id] = entity
 
-class GrentonClimate(ClimateEntity):
+class GrentonClimate(GrentonPollingMixin, ClimateEntity):
     _enable_turn_on_off_backwards_compatibility = False
     
-    def __init__(self, api_endpoint, grenton_id, object_name, auto_update, update_interval):
+    def __init__(self, api_endpoint, grenton_id, object_name, auto_update, update_interval, api_client):
         self._api_endpoint = api_endpoint
         self._grenton_id = grenton_id
         self._name = object_name
@@ -71,21 +71,7 @@ class GrentonClimate(ClimateEntity):
         self._update_interval = update_interval
         self._unsub_interval = None
         self._initialized = False
-
-    async def async_added_to_hass(self):
-        self._initialized = True
-        if self._auto_update:
-            self._unsub_interval = async_track_time_interval(
-                self.hass, self._update_callback, timedelta(seconds=self._update_interval)
-            )
-            await self.async_update()
-
-    async def async_will_remove_from_hass(self):
-        if self._unsub_interval:
-            self._unsub_interval()
-
-    async def _update_callback(self, now):
-        await self.async_update()
+        self._api_client = api_client
 
     async def async_force_therm_state(self, state: int, direction: int):
         self._hvac_mode = HVACMode.OFF if state == 0 else (HVACMode.COOL if direction == 1 else HVACMode.HEAT)
@@ -102,10 +88,6 @@ class GrentonClimate(ClimateEntity):
     @property
     def name(self):
         return self._name
-
-    @property
-    def should_poll(self):
-        return True
 
     @property
     def temperature_unit(self):
@@ -150,11 +132,9 @@ class GrentonClimate(ClimateEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to set the climate temperature: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to set the climate temperature: %s", ex)
 
     async def async_set_hvac_mode(self, hvac_mode):
         try:
@@ -170,18 +150,16 @@ class GrentonClimate(ClimateEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to set the climate hvac_mode: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to set the climate hvac_mode: %s", ex)
         
 
     async def async_update(self):
         if not self._initialized:
             return
         
-        if self._last_command_time and self.hass.loop.time() - self._last_command_time < 2:
+        if is_within_debounce(self._last_command_time, self.hass):
             return
         
         try:
@@ -190,14 +168,14 @@ class GrentonClimate(ClimateEntity):
             command.update({"status_2": f"return {grenton_id_part_0}:execute(0, '{grenton_id_part_1}:get(7)')"})
             command.update({"status_3": f"return {grenton_id_part_0}:execute(0, '{grenton_id_part_1}:get(12)')"})
             command.update({"status_4": f"return {grenton_id_part_0}:execute(0, '{grenton_id_part_1}:get(14)')"})
-            async with aiohttp.ClientSession() as session:
-                async with session.get(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-                    self._hvac_mode = HVACMode.OFF if data.get("status") == 0 else (HVACMode.COOL if data.get("status_2") == 1 else HVACMode.HEAT)
-                    self._target_temperature = data.get("status_3")
-                    self._current_temperature = data.get("status_4")
-                    self.async_write_ha_state()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to update the climate state: {ex}")
-            self._hvac_mode = HVACMode.OFF
+            data = await self._api_client.get_status(command)
+
+            if is_within_debounce(self._last_command_time, self.hass):
+                return
+
+            self._hvac_mode = HVACMode.OFF if data.get("status") == 0 else (HVACMode.COOL if data.get("status_2") == 1 else HVACMode.HEAT)
+            self._target_temperature = data.get("status_3")
+            self._current_temperature = data.get("status_4")
+            self.async_write_ha_state()
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to update the climate state: %s", ex)

--- a/custom_components/grenton_objects/const.py
+++ b/custom_components/grenton_objects/const.py
@@ -36,6 +36,7 @@ CONF_UNIT_OF_MEASUREMENT = 'unit_of_measurement'
 CONF_AUTO_UPDATE = 'auto_update'
 CONF_UPDATE_INTERVAL = "update_interval"
 DEFAULT_UPDATE_INTERVAL = 30  # sekundy
+COMMAND_DEBOUNCE_SECONDS = 2  # ignore poll results this many seconds after a command
 
 DEVICE_TYPE_OPTIONS = [
     "light",

--- a/custom_components/grenton_objects/cover.py
+++ b/custom_components/grenton_objects/cover.py
@@ -19,6 +19,8 @@ from .const import (
     DOMAIN,
     CONF_DEVICE_CLASS
 )
+from .api import get_api_client, GrentonApiError
+from .mixins import GrentonPollingMixin, is_within_debounce
 import logging
 import voluptuous as vol
 from homeassistant.components.cover import (
@@ -33,8 +35,6 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING
 )
-from datetime import timedelta
-from homeassistant.helpers.event import async_track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,7 +55,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
     device_class = config_entry.options.get(CONF_DEVICE_CLASS, config_entry.data.get(CONF_DEVICE_CLASS, CoverDeviceClass.BLIND.value))
 
-    entity = GrentonCover(api_endpoint, grenton_id, reversed, object_name, auto_update, update_interval, device_class)
+    api_client = get_api_client(hass, api_endpoint)
+    entity = GrentonCover(api_endpoint, grenton_id, reversed, object_name, auto_update, update_interval, device_class, api_client)
     async_add_entities([entity], True)
 
     if DOMAIN not in hass.data:
@@ -63,8 +64,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     hass.data[DOMAIN]["entities"][entity.entity_id] = entity
 
-class GrentonCover(CoverEntity):
-    def __init__(self, api_endpoint, grenton_id, reversed, object_name, auto_update, update_interval, device_class):
+class GrentonCover(GrentonPollingMixin, CoverEntity):
+    def __init__(self, api_endpoint, grenton_id, reversed, object_name, auto_update, update_interval, device_class, api_client):
         self._device_class = device_class
         self._api_endpoint = api_endpoint
         self._grenton_id = grenton_id
@@ -79,21 +80,7 @@ class GrentonCover(CoverEntity):
         self._update_interval = update_interval
         self._unsub_interval = None
         self._initialized = False
-
-    async def async_added_to_hass(self):
-        self._initialized = True
-        if self._auto_update:
-            self._unsub_interval = async_track_time_interval(
-                self.hass, self._update_callback, timedelta(seconds=self._update_interval)
-            )
-            await self.async_update()
-
-    async def async_will_remove_from_hass(self):
-        if self._unsub_interval:
-            self._unsub_interval()
-
-    async def _update_callback(self, now):
-        await self.async_update()
+        self._api_client = api_client
 
     async def async_force_cover(self, state: int, position: int, lamel: int):
         if self._reversed:
@@ -171,11 +158,9 @@ class GrentonCover(CoverEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to open the cover: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to open the cover: %s", ex)
 
     async def async_close_cover(self, **kwargs):
         try:
@@ -185,11 +170,9 @@ class GrentonCover(CoverEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to close the cover: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to close the cover: %s", ex)
 
     async def async_stop_cover(self, **kwargs):
         try:
@@ -199,11 +182,9 @@ class GrentonCover(CoverEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to stop the cover: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to stop the cover: %s", ex)
 
     async def async_set_cover_position(self, **kwargs):
         try:
@@ -229,11 +210,9 @@ class GrentonCover(CoverEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to set the cover position: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to set the cover position: %s", ex)
 
     async def async_set_cover_tilt_position(self, **kwargs):
         try:
@@ -245,11 +224,9 @@ class GrentonCover(CoverEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to set the cover tilt position: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to set the cover tilt position: %s", ex)
 
     async def async_open_cover_tilt(self, **kwargs):
         try:
@@ -258,11 +235,9 @@ class GrentonCover(CoverEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to open the cover tilt: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to open the cover tilt: %s", ex)
 
     async def async_close_cover_tilt(self, **kwargs):
         try:
@@ -271,17 +246,15 @@ class GrentonCover(CoverEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to close the cover tilt: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to close the cover tilt: %s", ex)
 
     async def async_update(self):
         if not self._initialized:
             return
         
-        if self._last_command_time and self.hass.loop.time() - self._last_command_time < 2:
+        if is_within_debounce(self._last_command_time, self.hass):
             return
             
         try:
@@ -298,22 +271,26 @@ class GrentonCover(CoverEntity):
                 command.update({"status_3": f"return {grenton_id_part_0}:execute(0, '{grenton_id_part_1}:get(6)')"})
             else:
                 command.update({"status_3": f"return {grenton_id_part_0}:execute(0, '{grenton_id_part_1}:get(8)')"})
-            async with aiohttp.ClientSession() as session:
-                async with session.get(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-                    position = data.get("status_2")
-                    if self._reversed:
-                        position = 100 - position
-                    self._state = STATE_CLOSED if position == 0 else STATE_OPEN
-                    if data.get("status") == 1:
-                        self._state = STATE_OPENING
-                    elif data.get("status") == 2:
-                        self._state = STATE_CLOSING
-                    self._current_cover_position = position
-                    angle = data.get("status_3", 0)
-                    self._current_cover_tilt_position = int((90 - angle) * 100 / 90)
-                    self.async_write_ha_state()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to update the cover state: {ex}")
+            data = await self._api_client.get_status(command)
+
+            if is_within_debounce(self._last_command_time, self.hass):
+                return
+
+            position = data.get("status_2")
+            if position is None:
+                _LOGGER.warning("Cover position unavailable (status_2 missing)")
+                return
+            if self._reversed:
+                position = 100 - position
+            self._state = STATE_CLOSED if position == 0 else STATE_OPEN
+            if data.get("status") == 1:
+                self._state = STATE_OPENING
+            elif data.get("status") == 2:
+                self._state = STATE_CLOSING
+            self._current_cover_position = position
+            angle = data.get("status_3", 0)
+            self._current_cover_tilt_position = int((90 - angle) * 100 / 90)
+            self.async_write_ha_state()
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to update the cover state: %s", ex)
             self._state = None

--- a/custom_components/grenton_objects/light.py
+++ b/custom_components/grenton_objects/light.py
@@ -28,6 +28,8 @@ from .const import (
     LIGHT_GRENTON_TYPE_LED,
     LIGHT_GRENTON_TYPE_BRIGHTNESS
 )
+from .api import get_api_client, GrentonApiError
+from .mixins import GrentonPollingMixin, is_within_debounce
 import logging
 import voluptuous as vol
 from homeassistant.components.light import (
@@ -37,8 +39,6 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import (STATE_ON, STATE_OFF)
 from homeassistant.util import color as color_util
-from datetime import timedelta
-from homeassistant.helpers.event import async_track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +57,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     auto_update = config_entry.options.get(CONF_AUTO_UPDATE, config_entry.data.get(CONF_AUTO_UPDATE, True))
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
     
-    entity = GrentonLight(api_endpoint, grenton_id, grenton_type, object_name, auto_update, update_interval)
+    api_client = get_api_client(hass, api_endpoint)
+    entity = GrentonLight(api_endpoint, grenton_id, grenton_type, object_name, auto_update, update_interval, api_client)
     async_add_entities([entity], True)
 
     if DOMAIN not in hass.data:
@@ -65,12 +66,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     hass.data[DOMAIN]["entities"][entity.entity_id] = entity
 
-class GrentonLight(LightEntity):
-    def __init__(self, api_endpoint, grenton_id, grenton_type, object_name, auto_update, update_interval):
+class GrentonLight(GrentonPollingMixin, LightEntity):
+    def __init__(self, api_endpoint, grenton_id, grenton_type, object_name, auto_update, update_interval, api_client):
         self._grenton_id = grenton_id
         self._api_endpoint = api_endpoint
         self._grenton_type = grenton_type
         self._object_name = object_name
+        self._api_client = api_client
         self._state = None
         self._supported_color_modes: set[ColorMode | str] = set()
         self._brightness = None
@@ -102,21 +104,6 @@ class GrentonLight(LightEntity):
             self._color_mode = ColorMode.RGB
         else:
             self._supported_color_modes.add(ColorMode.ONOFF)
-
-    async def async_added_to_hass(self):
-        self._initialized = True
-        if self._auto_update:
-            self._unsub_interval = async_track_time_interval(
-                self.hass, self._update_callback, timedelta(seconds=self._update_interval)
-            )
-            await self.async_update()
-
-    async def async_will_remove_from_hass(self):
-        if self._unsub_interval:
-            self._unsub_interval()
-
-    async def _update_callback(self, now):
-        await self.async_update()
 
     async def async_force_state(self, state: int):
         self._state = STATE_ON if state == 1 else STATE_OFF
@@ -289,11 +276,9 @@ class GrentonLight(LightEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to turn on the light: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to turn on the light: %s", ex)
             
     async def async_turn_off(self, **kwargs):
         try:
@@ -325,17 +310,15 @@ class GrentonLight(LightEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to turn off the light: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to turn off the light: %s", ex)
 
     async def async_update(self):
         if not self._initialized:
             return
         
-        if self._last_command_time and self.hass.loop.time() - self._last_command_time < 2:
+        if is_within_debounce(self._last_command_time, self.hass):
             return
             
         try:
@@ -364,44 +347,53 @@ class GrentonLight(LightEntity):
             if self._grenton_type == CONF_GRENTON_TYPE_RGBW:
                 command.update(self._generate_get_command("status_3", grenton_id_part_0, grenton_id_part_1, "get", 15))
             
-            async with aiohttp.ClientSession() as session:
-                async with session.get(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-                    self._state = STATE_OFF if data.get("status") == 0 else STATE_ON
-                    if self._grenton_type == CONF_GRENTON_TYPE_RGB or self._grenton_type == CONF_GRENTON_TYPE_DIMMER:
-                        if self._grenton_type == CONF_GRENTON_TYPE_DIMMER and grenton_id_part_1.startswith("ZWA"):
-                            self._brightness = data.get("status")
-                            self._last_brightness = data.get("status")
-                        else:
-                            self._brightness = data.get("status") * 255
-                            self._last_brightness = data.get("status") * 255
-                    elif self._grenton_type == CONF_GRENTON_TYPE_LED_R or self._grenton_type == CONF_GRENTON_TYPE_LED_G or self._grenton_type == CONF_GRENTON_TYPE_LED_B or self._grenton_type == CONF_GRENTON_TYPE_LED_W:
-                        self._brightness = data.get("status")
-                        self._last_brightness = data.get("status")
-                    
-                    if self._grenton_type == CONF_GRENTON_TYPE_RGB:
-                        self._rgb_color = color_util.rgb_hex_to_rgb_list(data.get("status_2").strip("#"))
+            data = await self._api_client.get_status(command)
 
-                    #rgbw
-                    if self._grenton_type == CONF_GRENTON_TYPE_RGBW:
-                        if data.get("status_3") > 0:
-                            self._state = STATE_ON
-                            self._color_mode = ColorMode.WHITE
-                            self._white = data.get("status_3")
-                            self._brightness = data.get("status_3")
-                            self._last_brightness = data.get("status_3")
-                        elif data.get("status") > 0:
-                            self._state = STATE_ON
-                            self._color_mode = ColorMode.RGB
-                            self._rgb_color = color_util.rgb_hex_to_rgb_list(data.get("status_2").strip("#"))
-                            self._brightness = data.get("status") * 255
-                            self._last_brightness = data.get("status") * 255
-                        else:
-                            self._state = STATE_OFF
+            if is_within_debounce(self._last_command_time, self.hass):
+                return
 
-                    self.async_write_ha_state()
+            self._state = STATE_OFF if data.get("status") == 0 else STATE_ON
+            if self._grenton_type == CONF_GRENTON_TYPE_RGB or self._grenton_type == CONF_GRENTON_TYPE_DIMMER:
+                if self._grenton_type == CONF_GRENTON_TYPE_DIMMER and grenton_id_part_1.startswith("ZWA"):
+                    self._brightness = data.get("status")
+                    self._last_brightness = data.get("status")
+                else:
+                    self._brightness = data.get("status") * 255
+                    self._last_brightness = data.get("status") * 255
+            elif self._grenton_type == CONF_GRENTON_TYPE_LED_R or self._grenton_type == CONF_GRENTON_TYPE_LED_G or self._grenton_type == CONF_GRENTON_TYPE_LED_B or self._grenton_type == CONF_GRENTON_TYPE_LED_W:
+                self._brightness = data.get("status")
+                self._last_brightness = data.get("status")
+            
+            if self._grenton_type == CONF_GRENTON_TYPE_RGB:
+                rgb_hex = data.get("status_2")
+                if rgb_hex:
+                    self._rgb_color = color_util.rgb_hex_to_rgb_list(rgb_hex.strip("#"))
 
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to update the light state: {ex}")
+            #rgbw
+            if self._grenton_type == CONF_GRENTON_TYPE_RGBW:
+                status_3 = data.get("status_3")
+                if status_3 is not None and status_3 > 0:
+                    self._state = STATE_ON
+                    self._color_mode = ColorMode.WHITE
+                    self._white = status_3
+                    self._brightness = status_3
+                    self._last_brightness = status_3
+                elif data.get("status") is not None and data.get("status") > 0:
+                    self._state = STATE_ON
+                    self._color_mode = ColorMode.RGB
+                    rgb_hex = data.get("status_2")
+                    if rgb_hex:
+                        self._rgb_color = color_util.rgb_hex_to_rgb_list(rgb_hex.strip("#"))
+                    self._brightness = data.get("status") * 255
+                    self._last_brightness = data.get("status") * 255
+                else:
+                    self._state = STATE_OFF
+
+            self.async_write_ha_state()
+
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to update the light state: %s", ex)
+            self._state = None
+        except (AttributeError, TypeError, ValueError) as ex:
+            _LOGGER.error("Unexpected data in light state response: %s", ex)
             self._state = None

--- a/custom_components/grenton_objects/mixins.py
+++ b/custom_components/grenton_objects/mixins.py
@@ -1,0 +1,44 @@
+"""Shared mixins for Grenton Objects entity classes."""
+
+from datetime import timedelta
+from homeassistant.helpers.event import async_track_time_interval
+
+from .const import COMMAND_DEBOUNCE_SECONDS
+
+
+def is_within_debounce(last_command_time, hass) -> bool:
+    """Return True if a command was sent recently and poll results should be ignored."""
+    if last_command_time is None:
+        return False
+    if hass is None or not hasattr(hass, 'loop') or hass.loop is None:
+        return False
+    if not callable(getattr(hass.loop, 'time', None)):
+        return False
+    return hass.loop.time() - last_command_time < COMMAND_DEBOUNCE_SECONDS
+    
+
+class GrentonPollingMixin:
+    """Mixin providing auto-update polling lifecycle for Grenton entities.
+
+    Expects the entity to define:
+        _auto_update: bool
+        _update_interval: int (seconds)
+        _initialized: bool (initially False)
+        _unsub_interval: callable | None (initially None)
+        async_update(): coroutine
+    """
+
+    async def async_added_to_hass(self):
+        self._initialized = True
+        if self._auto_update:
+            self._unsub_interval = async_track_time_interval(
+                self.hass, self._update_callback, timedelta(seconds=self._update_interval)
+            )
+            await self.async_update()
+
+    async def async_will_remove_from_hass(self):
+        if self._unsub_interval:
+            self._unsub_interval()
+
+    async def _update_callback(self, now):
+        await self.async_update()

--- a/custom_components/grenton_objects/sensor.py
+++ b/custom_components/grenton_objects/sensor.py
@@ -30,6 +30,8 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN
 )
+from .api import get_api_client, GrentonApiError
+from .mixins import GrentonPollingMixin
 import logging
 import voluptuous as vol
 import re
@@ -38,8 +40,6 @@ from homeassistant.components.sensor import (
     PLATFORM_SCHEMA
 )
 from homeassistant.const import UnitOfTemperature
-from datetime import timedelta
-from homeassistant.helpers.event import async_track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,7 +111,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     auto_update = config_entry.options.get(CONF_AUTO_UPDATE, config_entry.data.get(CONF_AUTO_UPDATE, True))
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
     
-    entity = GrentonSensor(api_endpoint, grenton_id, grenton_type, object_name, unit_of_measurement, device_class, state_class, auto_update, update_interval)
+    api_client = get_api_client(hass, api_endpoint)
+    entity = GrentonSensor(api_endpoint, grenton_id, grenton_type, object_name, unit_of_measurement, device_class, state_class, auto_update, update_interval, api_client)
     async_add_entities([entity], True)
 
     if DOMAIN not in hass.data:
@@ -120,8 +121,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DOMAIN]["entities"][entity.entity_id] = entity
     
     
-class GrentonSensor(SensorEntity):
-    def __init__(self, api_endpoint, grenton_id, grenton_type, object_name, unit_of_measurement, device_class, state_class, auto_update, update_interval):
+class GrentonSensor(GrentonPollingMixin, SensorEntity):
+    def __init__(self, api_endpoint, grenton_id, grenton_type, object_name, unit_of_measurement, device_class, state_class, auto_update, update_interval, api_client):
         self._api_endpoint = api_endpoint
         self._grenton_id = grenton_id
         self._grenton_type = grenton_type
@@ -134,26 +135,12 @@ class GrentonSensor(SensorEntity):
         self._update_interval = update_interval
         self._unsub_interval = None
         self._initialized = False
+        self._api_client = api_client
 
         if self._grenton_type == CONF_GRENTON_TYPE_RELAY_POWER:
             self._unique_id = f"grenton_{grenton_id.split('->')[1]}_POWER"
         else:
             self._unique_id = f"grenton_{grenton_id.split('->')[1] if '->' in grenton_id else grenton_id}"
-
-    async def async_added_to_hass(self):
-        self._initialized = True
-        if self._auto_update:
-            self._unsub_interval = async_track_time_interval(
-                self.hass, self._update_callback, timedelta(seconds=self._update_interval)
-            )
-            await self.async_update()
-
-    async def async_will_remove_from_hass(self):
-        if self._unsub_interval:
-            self._unsub_interval()
-
-    async def _update_callback(self, now):
-        await self.async_update()
 
     async def async_force_value(self, value: float):
         self._native_value = value
@@ -210,12 +197,9 @@ class GrentonSensor(SensorEntity):
             else:
                 command = {"status": f"return {self._grenton_id.split('->')[0]}:execute(0, 'getVar(\"{self._grenton_id.split('->')[1]}\")')"}
             
-            async with aiohttp.ClientSession() as session:
-                async with session.get(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-                    self._native_value = data.get("status")
-                    self.async_write_ha_state()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to update the sensor value: {ex}")
+            data = await self._api_client.get_status(command)
+            self._native_value = data.get("status")
+            self.async_write_ha_state()
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to update the sensor value: %s", ex)
             self._native_value = None

--- a/custom_components/grenton_objects/switch.py
+++ b/custom_components/grenton_objects/switch.py
@@ -17,6 +17,8 @@ from .const import (
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN
 )
+from .api import get_api_client, GrentonApiError
+from .mixins import GrentonPollingMixin, is_within_debounce
 
 import logging
 import voluptuous as vol
@@ -25,8 +27,6 @@ from homeassistant.components.switch import (
     PLATFORM_SCHEMA
 )
 from homeassistant.const import (STATE_ON, STATE_OFF)
-from datetime import timedelta
-from homeassistant.helpers.event import async_track_time_interval
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +43,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     auto_update = config_entry.options.get(CONF_AUTO_UPDATE, config_entry.data.get(CONF_AUTO_UPDATE, True))
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, config_entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL))
 
-    entity = GrentonSwitch(api_endpoint, grenton_id, object_name, auto_update, update_interval)
+    api_client = get_api_client(hass, api_endpoint)
+    entity = GrentonSwitch(api_endpoint, grenton_id, object_name, auto_update, update_interval, api_client)
     async_add_entities([entity], True)
 
     if DOMAIN not in hass.data:
@@ -51,8 +52,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     hass.data[DOMAIN]["entities"][entity.entity_id] = entity
 
-class GrentonSwitch(SwitchEntity):
-    def __init__(self, api_endpoint, grenton_id, object_name, auto_update, update_interval):
+class GrentonSwitch(GrentonPollingMixin, SwitchEntity):
+    def __init__(self, api_endpoint, grenton_id, object_name, auto_update, update_interval, api_client):
         self._api_endpoint = api_endpoint
         self._grenton_id = grenton_id
         self._object_name = object_name
@@ -63,21 +64,7 @@ class GrentonSwitch(SwitchEntity):
         self._update_interval = update_interval
         self._unsub_interval = None
         self._initialized = False
-
-    async def async_added_to_hass(self):
-        self._initialized = True
-        if self._auto_update:
-            self._unsub_interval = async_track_time_interval(
-                self.hass, self._update_callback, timedelta(seconds=self._update_interval)
-            )
-            await self.async_update()
-
-    async def async_will_remove_from_hass(self):
-        if self._unsub_interval:
-            self._unsub_interval()
-
-    async def _update_callback(self, now):
-        await self.async_update()
+        self._api_client = api_client
 
     async def async_force_state(self, state: int):
         self._state = STATE_ON if state == 1 else STATE_OFF
@@ -107,11 +94,9 @@ class GrentonSwitch(SwitchEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to turn on the switch: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to turn on the switch: %s", ex)
 
     async def async_turn_off(self, **kwargs):
         try:
@@ -121,28 +106,27 @@ class GrentonSwitch(SwitchEntity):
             self._last_command_time = self.hass.loop.time() if self.hass is not None else None
             self.async_write_ha_state()
             
-            async with aiohttp.ClientSession() as session:
-                async with session.post(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to turn off the switch: {ex}")
+            await self._api_client.send_command(command)
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to turn off the switch: %s", ex)
 
     async def async_update(self):
         if not self._initialized:
             return
         
-        if self._last_command_time and self.hass.loop.time() - self._last_command_time < 2:
+        if is_within_debounce(self._last_command_time, self.hass):
             return
             
         try:
             grenton_id_part_0, grenton_id_part_1 = self._grenton_id.split('->')
             command = {"status": f"return {grenton_id_part_0}:execute(0, '{grenton_id_part_1}:get(0)')"}
-            async with aiohttp.ClientSession() as session:
-                async with session.get(f"{self._api_endpoint}", json=command) as response:
-                    response.raise_for_status()
-                    data = await response.json()
-                    self._state = STATE_OFF if data.get("status") == 0 else STATE_ON
-                    self.async_write_ha_state()
-        except aiohttp.ClientError as ex:
-            _LOGGER.error(f"Failed to update the switch state: {ex}")
+            data = await self._api_client.get_status(command)
+
+            if is_within_debounce(self._last_command_time, self.hass):
+                return
+
+            self._state = STATE_OFF if data.get("status") == 0 else STATE_ON
+            self.async_write_ha_state()
+        except (aiohttp.ClientError, GrentonApiError) as ex:
+            _LOGGER.error("Failed to update the switch state: %s", ex)
             self._state = None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,30 @@
+"""Shared test mocks and helpers for Grenton Objects tests."""
+
+
+class MockApiClient:
+    """Mock API client that captures commands and returns predefined responses."""
+
+    def __init__(self, response_data=None, captured_command=None):
+        self._response_data = response_data if response_data is not None else {"status": "ok"}
+        self._captured_command = captured_command
+
+    async def send_command(self, command):
+        if self._captured_command is not None:
+            self._captured_command["value"] = command
+        return self._response_data
+
+    async def get_status(self, query):
+        if self._captured_command is not None:
+            self._captured_command["value"] = query
+        return self._response_data
+
+
+class MockLoop:
+    def time(self):
+        return 123.456
+
+
+class MockHass:
+    def async_add_job(self, *args, **kwargs):
+        pass
+    loop = MockLoop()

--- a/tests/test_api_batching.py
+++ b/tests/test_api_batching.py
@@ -1,0 +1,125 @@
+"""Tests for GrentonApiClient command batching logic."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.grenton_objects.api import GrentonApiClient, GrentonApiError
+
+
+def _make_mock_session(response_data):
+    """Create a mock aiohttp session with a preconfigured POST response."""
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = AsyncMock(return_value=response_data)
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.post = MagicMock(return_value=mock_response)
+    return mock_session
+
+
+@pytest.mark.asyncio
+async def test_single_command_sends_one_post():
+    """A single send_command should result in exactly one POST with key 'command'."""
+    mock_session = _make_mock_session({"command": "OK"})
+    client = GrentonApiClient("http://fake-gate", mock_session, batch_window=0.0)
+
+    result = await client.send_command({"command": "CLU:execute(0, 'DOU:set(0, 1)')"})
+
+    assert result == {"command": "OK"}
+    mock_session.post.assert_called_once()
+    payload = mock_session.post.call_args[1]["json"]
+    assert payload == {"command": "CLU:execute(0, 'DOU:set(0, 1)')"}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_commands_batched_into_single_post():
+    """Multiple send_command calls in the same tick should merge into one POST."""
+    mock_session = _make_mock_session({
+        "command": "result_1",
+        "command_2": "result_2",
+        "command_3": "result_3",
+    })
+    client = GrentonApiClient("http://fake-gate", mock_session, batch_window=0.0)
+
+    # Fire three commands concurrently (same event-loop tick)
+    results = await asyncio.gather(
+        client.send_command({"command": "cmd_a"}),
+        client.send_command({"command": "cmd_b"}),
+        client.send_command({"command": "cmd_c"}),
+    )
+
+    # Should have been a single POST
+    assert mock_session.post.call_count == 1
+    payload = mock_session.post.call_args[1]["json"]
+    # Payload should contain command, command_2, command_3
+    assert "command" in payload
+    assert "command_2" in payload
+    assert "command_3" in payload
+
+    # Each caller gets its correct result
+    assert results[0] == {"command": "result_1"}
+    assert results[1] == {"command": "result_2"}
+    assert results[2] == {"command": "result_3"}
+
+
+@pytest.mark.asyncio
+async def test_multi_key_command_batched_correctly():
+    """A command dict with multiple keys should generate sequential numbered keys."""
+    mock_session = _make_mock_session({
+        "command": "res_a",
+        "command_2": "res_b",
+    })
+    client = GrentonApiClient("http://fake-gate", mock_session, batch_window=0.0)
+
+    result = await client.send_command({
+        "command": "set_temp",
+        "command_2": "set_mode",
+    })
+
+    assert result == {"command": "res_a", "command_2": "res_b"}
+    payload = mock_session.post.call_args[1]["json"]
+    assert payload == {"command": "set_temp", "command_2": "set_mode"}
+
+
+@pytest.mark.asyncio
+async def test_failure_rejects_all_futures_with_grenton_api_error():
+    """When POST fails with a non-aiohttp error, futures get GrentonApiError."""
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = AsyncMock(side_effect=ValueError("bad json"))
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = MagicMock()
+    mock_session.post = MagicMock(return_value=mock_response)
+
+    client = GrentonApiClient("http://fake-gate", mock_session, batch_window=0.0)
+
+    with pytest.raises(GrentonApiError):
+        await client.send_command({"command": "some_cmd"})
+
+
+@pytest.mark.asyncio
+async def test_batch_window_coalesces_staggered_commands():
+    """With a non-zero batch window, commands arriving within it are merged."""
+    mock_session = _make_mock_session({
+        "command": "r1",
+        "command_2": "r2",
+    })
+    client = GrentonApiClient("http://fake-gate", mock_session, batch_window=0.05)
+
+    # Send first command
+    task1 = asyncio.create_task(client.send_command({"command": "cmd_1"}))
+    # Small delay then send second (within batch window)
+    await asyncio.sleep(0.01)
+    task2 = asyncio.create_task(client.send_command({"command": "cmd_2"}))
+
+    results = await asyncio.gather(task1, task2)
+
+    # Both should be in a single POST
+    assert mock_session.post.call_count == 1
+    assert results[0] == {"command": "r1"}
+    assert results[1] == {"command": "r2"}

--- a/tests/test_binary_sensor_logic.py
+++ b/tests/test_binary_sensor_logic.py
@@ -1,46 +1,31 @@
 import pytest
 from custom_components.grenton_objects.binary_sensor import GrentonBinarySensor
 from homeassistant.const import STATE_ON, STATE_OFF
+from tests.helpers import MockApiClient, MockHass
 
-def create_obj(grenton_id="CLU220000000->DIN0000", response_data={"status": 1}, captured_command=None):
+
+def create_obj(grenton_id="CLU220000000->DIN0000", response_data=None, captured_command=None):
+    if response_data is None:
+        response_data = {"status": 1}
+    api_client = MockApiClient(response_data=response_data, captured_command=captured_command)
     obj = GrentonBinarySensor(
         api_endpoint="http://fake-api",
         grenton_id=grenton_id,
         object_name="Test Sensor",
         auto_update=False,
-        update_interval=5
+        update_interval=5,
+        api_client=api_client
     )
     obj._initialized = True
-
-    class MockHass:
-        def async_add_job(self, *args, **kwargs): pass
     obj.hass = MockHass()
     obj.async_write_ha_state = lambda: None
 
-    class FakeResponse:
-        async def json(self): return response_data
-        def raise_for_status(self): pass
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-
-    class FakeSession:
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-        def post(self, url, json):
-            captured_command["value"] = json
-            return FakeResponse()
-        def get(self, url, json):
-            if captured_command is not None:
-                captured_command["value"] = json
-            return FakeResponse()
-
-    return obj, FakeSession
+    return obj
 
 @pytest.mark.asyncio
-async def test_async_update(monkeypatch):
+async def test_async_update():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": 1}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": 1}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -51,10 +36,9 @@ async def test_async_update(monkeypatch):
     assert obj.unique_id == "grenton_DIN0000"
 
 @pytest.mark.asyncio
-async def test_async_update_off(monkeypatch):
+async def test_async_update_off():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": 0}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": 0}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {

--- a/tests/test_button_logic.py
+++ b/tests/test_button_logic.py
@@ -1,42 +1,27 @@
 import pytest
 from custom_components.grenton_objects.button import GrentonScript
+from tests.helpers import MockApiClient, MockHass
 
-def create_obj(grenton_id="my_script", response_data={"status": "ok"}, captured_command=None):
+
+def create_obj(grenton_id="my_script", response_data=None, captured_command=None):
+    if response_data is None:
+        response_data = {"status": "ok"}
+    api_client = MockApiClient(response_data=response_data, captured_command=captured_command)
     obj = GrentonScript(
         api_endpoint="http://fake-api",
         grenton_id=grenton_id,
-        object_name="Test Script"
+        object_name="Test Script",
+        api_client=api_client
     )
-
-    class MockHass:
-        def async_add_job(self, *args, **kwargs): pass
     obj.hass = MockHass()
     obj.async_write_ha_state = lambda: None
 
-    class FakeResponse:
-        async def json(self): return response_data
-        def raise_for_status(self): pass
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-
-    class FakeSession:
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-        def post(self, url, json):
-            captured_command["value"] = json
-            return FakeResponse()
-        def get(self, url, json):
-            if captured_command is not None:
-                captured_command["value"] = json
-            return FakeResponse()
-
-    return obj, FakeSession
+    return obj
 
 @pytest.mark.asyncio
-async def test_async_script_local(monkeypatch):
+async def test_async_script_local():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_press()
 
     assert captured_command["value"] == {
@@ -45,10 +30,9 @@ async def test_async_script_local(monkeypatch):
     assert obj.unique_id == "grenton_my_script"
 
 @pytest.mark.asyncio
-async def test_async_script_remote(monkeypatch):
+async def test_async_script_remote():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->my_script_2", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->my_script_2", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_press()
 
     assert captured_command["value"] == {

--- a/tests/test_climate_logic.py
+++ b/tests/test_climate_logic.py
@@ -1,99 +1,76 @@
 import pytest
 from custom_components.grenton_objects.climate import GrentonClimate
 from homeassistant.components.climate import HVACMode
+from tests.helpers import MockApiClient, MockHass
 
-def create_obj(grenton_id="CLU220000000->THE0000", response_data={"status": "ok"}, captured_command=None):
+
+def create_obj(grenton_id="CLU220000000->THE0000", response_data=None, captured_command=None):
+    if response_data is None:
+        response_data = {"status": "ok"}
+    api_client = MockApiClient(response_data=response_data, captured_command=captured_command)
     obj = GrentonClimate(
         api_endpoint="http://fake-api",
         grenton_id=grenton_id,
         object_name="Test obj",
         auto_update=False,
-        update_interval=5
+        update_interval=5,
+        api_client=api_client
     )
     obj._initialized = True
-
-    class MockLoop:
-        def time(self):
-            return 123.456
-
-    class MockHass:
-        def async_add_job(self, *args, **kwargs): pass
-        loop = MockLoop()
     obj.hass = MockHass()
     obj.async_write_ha_state = lambda: None
 
-    class FakeResponse:
-        async def json(self): return response_data
-        def raise_for_status(self): pass
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-
-    class FakeSession:
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-        def post(self, url, json):
-            captured_command["value"] = json
-            return FakeResponse()
-        def get(self, url, json):
-            if captured_command is not None:
-                captured_command["value"] = json
-            return FakeResponse()
-
-    return obj, FakeSession
+    return obj
 
 @pytest.mark.asyncio
-async def test_async_set_temperature(monkeypatch):
+async def test_async_set_temperature():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_set_temperature(temperature=20)
 
     assert captured_command["value"] == {
-        "command": "CLU220000000:execute(0, 'THE0000:set(8, 0)')", "command_2": f"CLU220000000:execute(0, 'THE0000:set(3, 20)')"
+        "command": "CLU220000000:execute(0, 'THE0000:set(8, 0)')", "command_2": "CLU220000000:execute(0, 'THE0000:set(3, 20)')"
     }
     assert obj._target_temperature == 20
     assert obj._last_command_time == 123.456
     assert obj.unique_id == "grenton_THE0000"
 
 @pytest.mark.asyncio
-async def test_async_set_hvac_mode_heat(monkeypatch):
+async def test_async_set_hvac_mode_heat():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_set_hvac_mode(HVACMode.HEAT)
 
     assert captured_command["value"] == {
-        "command": "CLU220000000:execute(0, 'THE0000:execute(0, 0)')", "command_2": f"CLU220000000:execute(0, 'THE0000:set(7, 0)')"
+        "command": "CLU220000000:execute(0, 'THE0000:execute(0, 0)')", "command_2": "CLU220000000:execute(0, 'THE0000:set(7, 0)')"
     }
     assert obj._last_command_time == 123.456
     assert obj.unique_id == "grenton_THE0000"
     assert obj._hvac_mode == HVACMode.HEAT
 
 @pytest.mark.asyncio
-async def test_async_set_hvac_mode_cool(monkeypatch):
+async def test_async_set_hvac_mode_cool():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_set_hvac_mode(HVACMode.COOL)
 
     assert captured_command["value"] == {
-        "command": "CLU220000000:execute(0, 'THE0000:execute(0, 0)')", "command_2": f"CLU220000000:execute(0, 'THE0000:set(7, 1)')"
+        "command": "CLU220000000:execute(0, 'THE0000:execute(0, 0)')", "command_2": "CLU220000000:execute(0, 'THE0000:set(7, 1)')"
     }
     assert obj._last_command_time == 123.456
     assert obj.unique_id == "grenton_THE0000"
     assert obj._hvac_mode == HVACMode.COOL
 
 @pytest.mark.asyncio
-async def test_async_update(monkeypatch):
+async def test_async_update():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": 1, "status_2": 1, "status_3": 22, "status_4": 19}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": 1, "status_2": 1, "status_3": 22, "status_4": 19}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
         "status": "return CLU220000000:execute(0, 'THE0000:get(6)')", "status_2": "return CLU220000000:execute(0, 'THE0000:get(7)')", "status_3": "return CLU220000000:execute(0, 'THE0000:get(12)')", "status_4": "return CLU220000000:execute(0, 'THE0000:get(14)')"
     }
-    assert obj._last_command_time == None
+    assert obj._last_command_time is None
     assert obj.unique_id == "grenton_THE0000"
     assert obj._hvac_mode == HVACMode.COOL
     assert obj.target_temperature == 22

--- a/tests/test_cover_logic.py
+++ b/tests/test_cover_logic.py
@@ -1,14 +1,18 @@
 import pytest
 from custom_components.grenton_objects.cover import GrentonCover
 from homeassistant.const import (
-    STATE_CLOSED,
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING
 )
 from homeassistant.components.cover import CoverDeviceClass
+from tests.helpers import MockApiClient, MockHass
 
-def create_obj(grenton_id="CLU220000000->ROL0000", response_data={"status": "ok"}, captured_command=None, reversed=False):
+
+def create_obj(grenton_id="CLU220000000->ROL0000", response_data=None, captured_command=None, reversed=False):
+    if response_data is None:
+        response_data = {"status": "ok"}
+    api_client = MockApiClient(response_data=response_data, captured_command=captured_command)
     obj = GrentonCover(
         api_endpoint="http://fake-api",
         grenton_id=grenton_id,
@@ -16,44 +20,19 @@ def create_obj(grenton_id="CLU220000000->ROL0000", response_data={"status": "ok"
         object_name="Test obj",
         auto_update=False,
         update_interval=5,
-        device_class = CoverDeviceClass.BLIND.value
+        device_class = CoverDeviceClass.BLIND.value,
+        api_client=api_client
     )
     obj._initialized = True
-
-    class MockLoop:
-        def time(self):
-            return 123.456
-
-    class MockHass:
-        def async_add_job(self, *args, **kwargs): pass
-        loop = MockLoop()
     obj.hass = MockHass()
     obj.async_write_ha_state = lambda: None
 
-    class FakeResponse:
-        async def json(self): return response_data
-        def raise_for_status(self): pass
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-
-    class FakeSession:
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-        def post(self, url, json):
-            captured_command["value"] = json
-            return FakeResponse()
-        def get(self, url, json):
-            if captured_command is not None:
-                captured_command["value"] = json
-            return FakeResponse()
-
-    return obj, FakeSession
+    return obj
 
 @pytest.mark.asyncio
-async def test_async_open_cover(monkeypatch):
+async def test_async_open_cover():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_open_cover()
 
     assert captured_command["value"] == {
@@ -65,10 +44,9 @@ async def test_async_open_cover(monkeypatch):
     assert obj.unique_id == "grenton_ROL0000"
 
 @pytest.mark.asyncio
-async def test_async_close_cover(monkeypatch):
+async def test_async_close_cover():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_close_cover()
 
     assert captured_command["value"] == {
@@ -80,10 +58,9 @@ async def test_async_close_cover(monkeypatch):
     assert obj.unique_id == "grenton_ROL0000"
 
 @pytest.mark.asyncio
-async def test_async_stop_cover(monkeypatch):
+async def test_async_stop_cover():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_stop_cover()
 
     assert captured_command["value"] == {
@@ -94,10 +71,9 @@ async def test_async_stop_cover(monkeypatch):
     assert obj.unique_id == "grenton_ROL0000"
 
 @pytest.mark.asyncio
-async def test_async_set_cover_position(monkeypatch):
+async def test_async_set_cover_position():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_set_cover_position(position=100)
 
     assert captured_command["value"] == {
@@ -109,10 +85,9 @@ async def test_async_set_cover_position(monkeypatch):
     assert obj.unique_id == "grenton_ROL0000"
 
 @pytest.mark.asyncio
-async def test_async_set_cover_position_reversed(monkeypatch):
+async def test_async_set_cover_position_reversed():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command, reversed = True)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command, reversed = True)
     await obj.async_set_cover_position(position=100)
 
     assert captured_command["value"] == {
@@ -124,10 +99,9 @@ async def test_async_set_cover_position_reversed(monkeypatch):
     assert obj.unique_id == "grenton_ROL0000"
 
 @pytest.mark.asyncio
-async def test_async_set_cover_position_zwave(monkeypatch):
+async def test_async_set_cover_position_zwave():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_set_cover_position(position=100)
 
     assert captured_command["value"] == {
@@ -139,10 +113,9 @@ async def test_async_set_cover_position_zwave(monkeypatch):
     assert obj.unique_id == "grenton_ZWA0000"
 
 @pytest.mark.asyncio
-async def test_async_set_cover_position_reversed_zwave(monkeypatch):
+async def test_async_set_cover_position_reversed_zwave():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", response_data={"status": "ok"}, captured_command=captured_command, reversed = True)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", response_data={"status": "ok"}, captured_command=captured_command, reversed = True)
     await obj.async_set_cover_position(position=100)
 
     assert captured_command["value"] == {
@@ -154,10 +127,9 @@ async def test_async_set_cover_position_reversed_zwave(monkeypatch):
     assert obj.unique_id == "grenton_ZWA0000"
 
 @pytest.mark.asyncio
-async def test_async_set_cover_tilt_position(monkeypatch):
+async def test_async_set_cover_tilt_position():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_set_cover_tilt_position(tilt_position=100)
 
     assert captured_command["value"] == {
@@ -167,10 +139,9 @@ async def test_async_set_cover_tilt_position(monkeypatch):
     assert obj.unique_id == "grenton_ROL0000"
 
 @pytest.mark.asyncio
-async def test_async_open_cover_tilt(monkeypatch):
+async def test_async_open_cover_tilt():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_open_cover_tilt()
 
     assert captured_command["value"] == {
@@ -180,10 +151,9 @@ async def test_async_open_cover_tilt(monkeypatch):
     assert obj.unique_id == "grenton_ROL0000"
 
 @pytest.mark.asyncio
-async def test_async_close_cover_tilt(monkeypatch):
+async def test_async_close_cover_tilt():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_close_cover_tilt()
 
     assert captured_command["value"] == {
@@ -193,10 +163,9 @@ async def test_async_close_cover_tilt(monkeypatch):
     assert obj.unique_id == "grenton_ROL0000"
 
 @pytest.mark.asyncio
-async def test_async_update(monkeypatch):
+async def test_async_update():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": 1, "status_2": 50, "status_3": 90}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": 1, "status_2": 50, "status_3": 90}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -208,10 +177,9 @@ async def test_async_update(monkeypatch):
     assert obj.current_cover_tilt_position == 0
 
 @pytest.mark.asyncio
-async def test_async_update_zwave(monkeypatch):
+async def test_async_update_zwave():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", response_data={"status": 0, "status_2": 50, "status_3": 90}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", response_data={"status": 0, "status_2": 50, "status_3": 90}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -223,10 +191,9 @@ async def test_async_update_zwave(monkeypatch):
     assert obj.current_cover_tilt_position == 0
 
 @pytest.mark.asyncio
-async def test_async_update_reversed(monkeypatch):
+async def test_async_update_reversed():
     captured_command = {}
-    obj, FakeSession = create_obj(response_data={"status": 0, "status_2": 100, "status_3": 90}, captured_command=captured_command, reversed = True)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(response_data={"status": 0, "status_2": 100, "status_3": 90}, captured_command=captured_command, reversed = True)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -238,10 +205,9 @@ async def test_async_update_reversed(monkeypatch):
     assert obj.current_cover_tilt_position == 0
 
 @pytest.mark.asyncio
-async def test_async_update_zwave_reversed(monkeypatch):
+async def test_async_update_zwave_reversed():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", response_data={"status": 2, "status_2": 100, "status_3": 0}, captured_command=captured_command, reversed = True)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", response_data={"status": 2, "status_2": 100, "status_3": 0}, captured_command=captured_command, reversed = True)
     await obj.async_update()
 
     assert captured_command["value"] == {

--- a/tests/test_debounce_logic.py
+++ b/tests/test_debounce_logic.py
@@ -1,0 +1,307 @@
+"""Tests for debounce utility and race guard logic."""
+
+import pytest
+from custom_components.grenton_objects.mixins import is_within_debounce
+from custom_components.grenton_objects.const import (
+    COMMAND_DEBOUNCE_SECONDS,
+    CONF_GRENTON_TYPE_DOUT,
+)
+from custom_components.grenton_objects.switch import GrentonSwitch
+from custom_components.grenton_objects.light import GrentonLight
+from custom_components.grenton_objects.cover import GrentonCover
+from custom_components.grenton_objects.climate import GrentonClimate
+from homeassistant.const import STATE_ON, STATE_OFF
+from homeassistant.components.climate import HVACMode
+from tests.helpers import MockApiClient
+
+
+class MockHassWithTime:
+    """MockHass with configurable loop time."""
+
+    def __init__(self, current_time=100.0):
+        self._time = current_time
+        self.loop = self
+
+    def time(self):
+        return self._time
+
+    def set_time(self, t):
+        self._time = t
+
+
+# --- is_within_debounce tests ---
+
+
+def test_is_within_debounce_no_command():
+    """Should return False when no command has been sent."""
+    hass = MockHassWithTime()
+    assert is_within_debounce(None, hass) is False
+
+
+def test_is_within_debounce_recent_command():
+    """Should return True when command was sent less than COMMAND_DEBOUNCE_SECONDS ago."""
+    hass = MockHassWithTime(current_time=100.0)
+    last_command_time = 99.5  # 0.5s ago
+    assert is_within_debounce(last_command_time, hass) is True
+
+
+def test_is_within_debounce_old_command():
+    """Should return False when command was sent more than COMMAND_DEBOUNCE_SECONDS ago."""
+    hass = MockHassWithTime(current_time=100.0)
+    last_command_time = 97.0  # 3s ago
+    assert is_within_debounce(last_command_time, hass) is False
+
+
+def test_is_within_debounce_exactly_at_boundary():
+    """Should return False when exactly at the debounce boundary."""
+    hass = MockHassWithTime(current_time=100.0)
+    last_command_time = 100.0 - COMMAND_DEBOUNCE_SECONDS
+    assert is_within_debounce(last_command_time, hass) is False
+
+
+# --- Race guard tests ---
+
+
+def create_switch(response_data=None, current_time=100.0):
+    if response_data is None:
+        response_data = {"status": 0}
+    api_client = MockApiClient(response_data=response_data)
+    obj = GrentonSwitch(
+        api_endpoint="http://fake-api",
+        grenton_id="CLU220000000->DOU0000",
+        object_name="Test Switch",
+        auto_update=False,
+        update_interval=5,
+        api_client=api_client,
+    )
+    obj._initialized = True
+    obj.hass = MockHassWithTime(current_time)
+    obj.async_write_ha_state = lambda: None
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_race_guard_skips_update_during_debounce():
+    """async_update should skip when within debounce window."""
+    obj = create_switch(response_data={"status": 0}, current_time=100.0)
+    # Simulate a command was just sent
+    obj._state = STATE_ON
+    obj._last_command_time = 99.5  # 0.5s ago
+
+    await obj.async_update()
+
+    # State should NOT be overwritten by the poll (which returns status=0 → OFF)
+    assert obj._state == STATE_ON
+
+
+@pytest.mark.asyncio
+async def test_race_guard_allows_update_after_debounce():
+    """async_update should proceed when debounce window has passed."""
+    obj = create_switch(response_data={"status": 0}, current_time=100.0)
+    # Simulate a command sent long ago
+    obj._state = STATE_ON
+    obj._last_command_time = 97.0  # 3s ago
+
+    await obj.async_update()
+
+    # State should be updated from the poll response
+    assert obj._state == STATE_OFF
+
+
+@pytest.mark.asyncio
+async def test_race_guard_post_await_check():
+    """If a command fires while HTTP is in-flight, result should be discarded."""
+    obj = create_switch(response_data={"status": 0}, current_time=100.0)
+    obj._last_command_time = None  # no recent command at start
+
+    # Monkey-patch the api_client to simulate a command firing during the HTTP call
+    original_get_status = obj._api_client.get_status
+
+    async def get_status_with_side_effect(query):
+        # Simulate: while waiting for HTTP response, a command was issued
+        obj._last_command_time = 100.0  # command fires "now"
+        return await original_get_status(query)
+
+    obj._api_client.get_status = get_status_with_side_effect
+
+    obj._state = STATE_ON  # optimistic state from the simulated command
+    await obj.async_update()
+
+    # The stale poll result (status=0 → OFF) should be discarded
+    assert obj._state == STATE_ON
+
+
+# --- Light race guard tests ---
+
+
+def create_light(response_data=None, current_time=100.0):
+    if response_data is None:
+        response_data = {"status": 0}
+    api_client = MockApiClient(response_data=response_data)
+    obj = GrentonLight(
+        api_endpoint="http://fake-api",
+        grenton_id="CLU220000000->DOU0000",
+        grenton_type=CONF_GRENTON_TYPE_DOUT,
+        object_name="Test Light",
+        auto_update=False,
+        update_interval=5,
+        api_client=api_client,
+    )
+    obj._initialized = True
+    obj.hass = MockHassWithTime(current_time)
+    obj.async_write_ha_state = lambda: None
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_light_race_guard_skips_update_during_debounce():
+    """Light async_update should skip when within debounce window."""
+    obj = create_light(response_data={"status": 0}, current_time=100.0)
+    obj._state = STATE_ON
+    obj._last_command_time = 99.5
+
+    await obj.async_update()
+
+    assert obj._state == STATE_ON
+
+
+@pytest.mark.asyncio
+async def test_light_race_guard_post_await_check():
+    """If a command fires while light HTTP is in-flight, result should be discarded."""
+    obj = create_light(response_data={"status": 0}, current_time=100.0)
+    obj._last_command_time = None
+
+    original_get_status = obj._api_client.get_status
+
+    async def get_status_with_side_effect(query):
+        obj._last_command_time = 100.0
+        return await original_get_status(query)
+
+    obj._api_client.get_status = get_status_with_side_effect
+    obj._state = STATE_ON
+    await obj.async_update()
+
+    assert obj._state == STATE_ON
+
+
+# --- Cover race guard tests ---
+
+
+def create_cover(response_data=None, current_time=100.0):
+    if response_data is None:
+        response_data = {"status": 0, "status_2": 50, "status_3": 0}
+    api_client = MockApiClient(response_data=response_data)
+    obj = GrentonCover(
+        api_endpoint="http://fake-api",
+        grenton_id="CLU220000000->ROL0000",
+        reversed=False,
+        object_name="Test Cover",
+        auto_update=False,
+        update_interval=5,
+        device_class="blind",
+        api_client=api_client,
+    )
+    obj._initialized = True
+    obj.hass = MockHassWithTime(current_time)
+    obj.async_write_ha_state = lambda: None
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_cover_race_guard_skips_update_during_debounce():
+    """Cover async_update should skip when within debounce window."""
+    from homeassistant.const import STATE_OPEN
+    obj = create_cover(response_data={"status": 0, "status_2": 0, "status_3": 0}, current_time=100.0)
+    obj._state = STATE_OPEN
+    obj._current_cover_position = 100
+    obj._last_command_time = 99.5
+
+    await obj.async_update()
+
+    assert obj._state == STATE_OPEN
+    assert obj._current_cover_position == 100
+
+
+@pytest.mark.asyncio
+async def test_cover_race_guard_post_await_check():
+    """If a command fires while cover HTTP is in-flight, result should be discarded."""
+    from homeassistant.const import STATE_OPEN
+    obj = create_cover(response_data={"status": 0, "status_2": 0, "status_3": 0}, current_time=100.0)
+    obj._last_command_time = None
+
+    original_get_status = obj._api_client.get_status
+
+    async def get_status_with_side_effect(query):
+        obj._last_command_time = 100.0
+        return await original_get_status(query)
+
+    obj._api_client.get_status = get_status_with_side_effect
+    obj._state = STATE_OPEN
+    obj._current_cover_position = 100
+    await obj.async_update()
+
+    assert obj._state == STATE_OPEN
+    assert obj._current_cover_position == 100
+
+
+# --- Climate race guard tests ---
+
+
+def create_climate(response_data=None, current_time=100.0):
+    if response_data is None:
+        response_data = {"status": 1, "status_2": 0, "status_3": 22.0, "status_4": 20.0}
+    api_client = MockApiClient(response_data=response_data)
+    obj = GrentonClimate(
+        api_endpoint="http://fake-api",
+        grenton_id="CLU220000000->THE0000",
+        object_name="Test Climate",
+        auto_update=False,
+        update_interval=5,
+        api_client=api_client,
+    )
+    obj._initialized = True
+    obj.hass = MockHassWithTime(current_time)
+    obj.async_write_ha_state = lambda: None
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_climate_race_guard_skips_update_during_debounce():
+    """Climate async_update should skip when within debounce window."""
+    # Response would set HEAT mode, but debounce should prevent update
+    obj = create_climate(
+        response_data={"status": 1, "status_2": 0, "status_3": 25.0, "status_4": 21.0},
+        current_time=100.0,
+    )
+    obj._hvac_mode = HVACMode.OFF
+    obj._target_temperature = 20.0
+    obj._last_command_time = 99.5
+
+    await obj.async_update()
+
+    assert obj._hvac_mode == HVACMode.OFF
+    assert obj._target_temperature == 20.0
+
+
+@pytest.mark.asyncio
+async def test_climate_race_guard_post_await_check():
+    """If a command fires while climate HTTP is in-flight, result should be discarded."""
+    obj = create_climate(
+        response_data={"status": 1, "status_2": 0, "status_3": 25.0, "status_4": 21.0},
+        current_time=100.0,
+    )
+    obj._last_command_time = None
+
+    original_get_status = obj._api_client.get_status
+
+    async def get_status_with_side_effect(query):
+        obj._last_command_time = 100.0
+        return await original_get_status(query)
+
+    obj._api_client.get_status = get_status_with_side_effect
+    obj._hvac_mode = HVACMode.OFF
+    obj._target_temperature = 20.0
+    await obj.async_update()
+
+    assert obj._hvac_mode == HVACMode.OFF
+    assert obj._target_temperature == 20.0

--- a/tests/test_init_unload.py
+++ b/tests/test_init_unload.py
@@ -1,0 +1,58 @@
+"""Tests for async_unload_entry client-cache eviction logic."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.grenton_objects import async_unload_entry
+from custom_components.grenton_objects.const import DOMAIN, CONF_API_ENDPOINT
+
+
+def _make_config_entry(entry_id, endpoint, device_type="switch"):
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.data = {
+        "device_type": device_type,
+        CONF_API_ENDPOINT: endpoint,
+    }
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_client_removed_when_last_entry_unloaded():
+    """Client is evicted from cache when the last entry using its endpoint is unloaded."""
+    endpoint = "http://192.168.0.10:9999"
+    entry = _make_config_entry("entry_1", endpoint)
+    mock_client = MagicMock()
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entities": {}, "clients": {endpoint: mock_client}}}
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    # No remaining entries reference this endpoint
+    hass.config_entries.async_entries = MagicMock(return_value=[entry])
+
+    result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    assert endpoint not in hass.data[DOMAIN]["clients"]
+    mock_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_client_retained_when_other_entry_shares_endpoint():
+    """Client stays in cache when another config entry still references the same endpoint."""
+    endpoint = "http://192.168.0.10:9999"
+    entry_to_unload = _make_config_entry("entry_1", endpoint)
+    other_entry = _make_config_entry("entry_2", endpoint)
+    mock_client = MagicMock()
+
+    hass = MagicMock()
+    hass.data = {DOMAIN: {"entities": {}, "clients": {endpoint: mock_client}}}
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    # Another entry still uses the same endpoint
+    hass.config_entries.async_entries = MagicMock(return_value=[entry_to_unload, other_entry])
+
+    result = await async_unload_entry(hass, entry_to_unload)
+
+    assert result is True
+    assert endpoint in hass.data[DOMAIN]["clients"]
+    assert hass.data[DOMAIN]["clients"][endpoint] is mock_client

--- a/tests/test_light_logic.py
+++ b/tests/test_light_logic.py
@@ -1,52 +1,32 @@
 import pytest
 from custom_components.grenton_objects.light import GrentonLight
 from homeassistant.const import STATE_ON, STATE_OFF
+from tests.helpers import MockApiClient, MockHass
 
-def create_obj(grenton_id="CLU220000000->DOU0000", grenton_type = "DOUT", response_data={"status": "ok"}, captured_command=None):
+
+def create_obj(grenton_id="CLU220000000->DOU0000", grenton_type = "DOUT", response_data=None, captured_command=None):
+    if response_data is None:
+        response_data = {"status": "ok"}
+    api_client = MockApiClient(response_data=response_data, captured_command=captured_command)
     obj = GrentonLight(
         api_endpoint="http://fake-api",
         grenton_id=grenton_id,
         object_name="Test obj",
         grenton_type = grenton_type,
         auto_update=False,
-        update_interval=5
+        update_interval=5,
+        api_client=api_client
     )
     obj._initialized = True
-
-    class MockLoop:
-        def time(self):
-            return 123.456
-
-    class MockHass:
-        def async_add_job(self, *args, **kwargs): pass
-        loop = MockLoop()
     obj.hass = MockHass()
     obj.async_write_ha_state = lambda: None
 
-    class FakeResponse:
-        async def json(self): return response_data
-        def raise_for_status(self): pass
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-
-    class FakeSession:
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-        def post(self, url, json):
-            captured_command["value"] = json
-            return FakeResponse()
-        def get(self, url, json):
-            if captured_command is not None:
-                captured_command["value"] = json
-            return FakeResponse()
-
-    return obj, FakeSession
+    return obj
 
 @pytest.mark.asyncio
-async def test_async_turn_on_dout(monkeypatch):
+async def test_async_turn_on_dout():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_type = "DOUT", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_type = "DOUT", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -58,10 +38,9 @@ async def test_async_turn_on_dout(monkeypatch):
     assert obj.unique_id == "grenton_DOU0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_dimmer(monkeypatch):
+async def test_async_turn_on_dimmer():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DIM0000", grenton_type = "DIMMER", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DIM0000", grenton_type = "DIMMER", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -74,10 +53,9 @@ async def test_async_turn_on_dimmer(monkeypatch):
     assert obj.unique_id == "grenton_DIM0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_dimmer_zwave(monkeypatch):
+async def test_async_turn_on_dimmer_zwave():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "DIMMER", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "DIMMER", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -90,10 +68,9 @@ async def test_async_turn_on_dimmer_zwave(monkeypatch):
     assert obj.unique_id == "grenton_ZWA0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_dimmer_rgbw_r(monkeypatch):
+async def test_async_turn_on_dimmer_rgbw_r():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_R", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_R", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -106,10 +83,9 @@ async def test_async_turn_on_dimmer_rgbw_r(monkeypatch):
     assert obj.unique_id == "grenton_LED0000_LED_R"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_dimmer_rgbw_g(monkeypatch):
+async def test_async_turn_on_dimmer_rgbw_g():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_G", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_G", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -122,10 +98,9 @@ async def test_async_turn_on_dimmer_rgbw_g(monkeypatch):
     assert obj.unique_id == "grenton_LED0000_LED_G"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_dimmer_rgbw_b(monkeypatch):
+async def test_async_turn_on_dimmer_rgbw_b():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_B", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_B", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -138,10 +113,9 @@ async def test_async_turn_on_dimmer_rgbw_b(monkeypatch):
     assert obj.unique_id == "grenton_LED0000_LED_B"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_dimmer_rgbw_w(monkeypatch):
+async def test_async_turn_on_dimmer_rgbw_w():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_W", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_W", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -154,10 +128,9 @@ async def test_async_turn_on_dimmer_rgbw_w(monkeypatch):
     assert obj.unique_id == "grenton_LED0000_LED_W"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_rgb(monkeypatch):
+async def test_async_turn_on_rgb():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "RGB", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "RGB", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on(rgb_color=[255, 255, 255])
 
     assert captured_command["value"] == {
@@ -170,10 +143,9 @@ async def test_async_turn_on_rgb(monkeypatch):
     assert obj.unique_id == "grenton_RGB0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_rgb_zwave(monkeypatch):
+async def test_async_turn_on_rgb_zwave():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "RGB", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "RGB", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on(rgb_color=[0, 0, 0])
 
     assert captured_command["value"] == {
@@ -186,10 +158,9 @@ async def test_async_turn_on_rgb_zwave(monkeypatch):
     assert obj.unique_id == "grenton_ZWA0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_on_rgb_no_rgb_color(monkeypatch):
+async def test_async_turn_on_rgb_no_rgb_color():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "RGB", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "RGB", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -201,10 +172,9 @@ async def test_async_turn_on_rgb_no_rgb_color(monkeypatch):
     assert obj.unique_id == "grenton_RGB0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_off_dout(monkeypatch):
+async def test_async_turn_off_dout():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_type = "DOUT", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_type = "DOUT", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
@@ -216,10 +186,9 @@ async def test_async_turn_off_dout(monkeypatch):
     assert obj.unique_id == "grenton_DOU0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_off_dimmer(monkeypatch):
+async def test_async_turn_off_dimmer():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DIM0000", grenton_type = "DIMMER", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DIM0000", grenton_type = "DIMMER", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
@@ -231,10 +200,9 @@ async def test_async_turn_off_dimmer(monkeypatch):
     assert obj.unique_id == "grenton_DIM0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_off_dimmer_zwave(monkeypatch):
+async def test_async_turn_off_dimmer_zwave():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "DIMMER", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "DIMMER", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
@@ -246,10 +214,9 @@ async def test_async_turn_off_dimmer_zwave(monkeypatch):
     assert obj.unique_id == "grenton_ZWA0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_off_rgb(monkeypatch):
+async def test_async_turn_off_rgb():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "RGB", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "RGB", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
@@ -261,10 +228,9 @@ async def test_async_turn_off_rgb(monkeypatch):
     assert obj.unique_id == "grenton_RGB0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_off_rgb_led_r(monkeypatch):
+async def test_async_turn_off_rgb_led_r():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "LED_R", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "LED_R", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
@@ -276,10 +242,9 @@ async def test_async_turn_off_rgb_led_r(monkeypatch):
     assert obj.unique_id == "grenton_RGB0000_LED_R"
 
 @pytest.mark.asyncio
-async def test_async_turn_off_rgb_led_g(monkeypatch):
+async def test_async_turn_off_rgb_led_g():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "LED_G", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "LED_G", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
@@ -291,10 +256,9 @@ async def test_async_turn_off_rgb_led_g(monkeypatch):
     assert obj.unique_id == "grenton_RGB0000_LED_G"
 
 @pytest.mark.asyncio
-async def test_async_turn_off_rgb_led_b(monkeypatch):
+async def test_async_turn_off_rgb_led_b():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "LED_B", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "LED_B", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
@@ -306,10 +270,9 @@ async def test_async_turn_off_rgb_led_b(monkeypatch):
     assert obj.unique_id == "grenton_RGB0000_LED_B"
 
 @pytest.mark.asyncio
-async def test_async_turn_off_rgb_led_w(monkeypatch):
+async def test_async_turn_off_rgb_led_w():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "LED_W", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->RGB0000", grenton_type = "LED_W", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
@@ -321,10 +284,9 @@ async def test_async_turn_off_rgb_led_w(monkeypatch):
     assert obj.unique_id == "grenton_RGB0000_LED_W"
 
 @pytest.mark.asyncio
-async def test_async_update_dout(monkeypatch):
+async def test_async_update_dout():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DOU0000", grenton_type = "DOUT", response_data={"status": 1}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DOU0000", grenton_type = "DOUT", response_data={"status": 1}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -335,10 +297,9 @@ async def test_async_update_dout(monkeypatch):
     assert obj.unique_id == "grenton_DOU0000"
 
 @pytest.mark.asyncio
-async def test_async_update_dout_off(monkeypatch):
+async def test_async_update_dout_off():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DOU0000", grenton_type = "DOUT", response_data={"status": 0}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DOU0000", grenton_type = "DOUT", response_data={"status": 0}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -349,10 +310,9 @@ async def test_async_update_dout_off(monkeypatch):
     assert obj.unique_id == "grenton_DOU0000"
 
 @pytest.mark.asyncio
-async def test_async_update_dimmer(monkeypatch):
+async def test_async_update_dimmer():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DIM0000", grenton_type = "DIMMER", response_data={"status": 1}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DIM0000", grenton_type = "DIMMER", response_data={"status": 1}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -364,10 +324,9 @@ async def test_async_update_dimmer(monkeypatch):
     assert obj.unique_id == "grenton_DIM0000"
 
 @pytest.mark.asyncio
-async def test_async_update_dimmer_off(monkeypatch):
+async def test_async_update_dimmer_off():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DIM0000", grenton_type = "DIMMER", response_data={"status": 0}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DIM0000", grenton_type = "DIMMER", response_data={"status": 0}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -379,10 +338,9 @@ async def test_async_update_dimmer_off(monkeypatch):
     assert obj.unique_id == "grenton_DIM0000"
 
 @pytest.mark.asyncio
-async def test_async_update_dimmer_zwave(monkeypatch):
+async def test_async_update_dimmer_zwave():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "DIMMER", response_data={"status": 255}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "DIMMER", response_data={"status": 255}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -394,10 +352,9 @@ async def test_async_update_dimmer_zwave(monkeypatch):
     assert obj.unique_id == "grenton_ZWA0000"
 
 @pytest.mark.asyncio
-async def test_async_update_dimmer_zwave_off(monkeypatch):
+async def test_async_update_dimmer_zwave_off():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "DIMMER", response_data={"status": 0}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "DIMMER", response_data={"status": 0}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -409,10 +366,9 @@ async def test_async_update_dimmer_zwave_off(monkeypatch):
     assert obj.unique_id == "grenton_ZWA0000"
 
 @pytest.mark.asyncio
-async def test_async_update_led_r(monkeypatch):
+async def test_async_update_led_r():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_R", response_data={"status": 255}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_R", response_data={"status": 255}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -424,10 +380,9 @@ async def test_async_update_led_r(monkeypatch):
     assert obj.unique_id == "grenton_LED0000_LED_R"
 
 @pytest.mark.asyncio
-async def test_async_update_led_g_off(monkeypatch):
+async def test_async_update_led_g_off():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_G", response_data={"status": 0}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_G", response_data={"status": 0}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -439,10 +394,9 @@ async def test_async_update_led_g_off(monkeypatch):
     assert obj.unique_id == "grenton_LED0000_LED_G"
 
 @pytest.mark.asyncio
-async def test_async_update_led_b_off(monkeypatch):
+async def test_async_update_led_b_off():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_B", response_data={"status": 0}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_B", response_data={"status": 0}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -454,10 +408,9 @@ async def test_async_update_led_b_off(monkeypatch):
     assert obj.unique_id == "grenton_LED0000_LED_B"
 
 @pytest.mark.asyncio
-async def test_async_update_led_w(monkeypatch):
+async def test_async_update_led_w():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_W", response_data={"status": 255}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "LED_W", response_data={"status": 255}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -469,10 +422,9 @@ async def test_async_update_led_w(monkeypatch):
     assert obj.unique_id == "grenton_LED0000_LED_W"
 
 @pytest.mark.asyncio
-async def test_async_update_rgb(monkeypatch):
+async def test_async_update_rgb():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "RGB", response_data={"status": 1, "status_2": "#000000"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "RGB", response_data={"status": 1, "status_2": "#000000"}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -485,10 +437,9 @@ async def test_async_update_rgb(monkeypatch):
     assert obj.unique_id == "grenton_LED0000"
 
 @pytest.mark.asyncio
-async def test_async_update_rgb_off(monkeypatch):
+async def test_async_update_rgb_off():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "RGB", response_data={"status": 0, "status_2": "#ffffff"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->LED0000", grenton_type = "RGB", response_data={"status": 0, "status_2": "#ffffff"}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -501,10 +452,9 @@ async def test_async_update_rgb_off(monkeypatch):
     assert obj.unique_id == "grenton_LED0000"
 
 @pytest.mark.asyncio
-async def test_async_update_rgb_zwave(monkeypatch):
+async def test_async_update_rgb_zwave():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "RGB", response_data={"status": 1, "status_2": "#ffffff"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->ZWA0000", grenton_type = "RGB", response_data={"status": 1, "status_2": "#ffffff"}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {

--- a/tests/test_sensor_logic.py
+++ b/tests/test_sensor_logic.py
@@ -1,7 +1,12 @@
 import pytest
 from custom_components.grenton_objects.sensor import GrentonSensor
+from tests.helpers import MockApiClient, MockHass
 
-def create_obj(grenton_id="CLU220000000->DIN0000", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "°C", device_class = "temperature", state_class = "measurement", response_data={"status": 1}, captured_command=None):
+
+def create_obj(grenton_id="CLU220000000->DIN0000", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "°C", device_class = "temperature", state_class = "measurement", response_data=None, captured_command=None):
+    if response_data is None:
+        response_data = {"status": 1}
+    api_client = MockApiClient(response_data=response_data, captured_command=captured_command)
     obj = GrentonSensor(
         api_endpoint="http://fake-api",
         grenton_id=grenton_id,
@@ -11,39 +16,19 @@ def create_obj(grenton_id="CLU220000000->DIN0000", grenton_type = "DEFAULT_SENSO
         device_class = device_class,
         state_class = state_class,
         auto_update=False,
-        update_interval=5
+        update_interval=5,
+        api_client=api_client
     )
     obj._initialized = True
-
-    class MockHass:
-        def async_add_job(self, *args, **kwargs): pass
     obj.hass = MockHass()
     obj.async_write_ha_state = lambda: None
 
-    class FakeResponse:
-        async def json(self): return response_data
-        def raise_for_status(self): pass
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-
-    class FakeSession:
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-        def post(self, url, json):
-            captured_command["value"] = json
-            return FakeResponse()
-        def get(self, url, json):
-            if captured_command is not None:
-                captured_command["value"] = json
-            return FakeResponse()
-
-    return obj, FakeSession
+    return obj
 
 @pytest.mark.asyncio
-async def test_async_update_panelsenstemp(monkeypatch):
+async def test_async_update_panelsenstemp():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->PAN0000", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "°C", device_class = "temperature", state_class = "measurement", response_data={"status": 22.4}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->PAN0000", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "°C", device_class = "temperature", state_class = "measurement", response_data={"status": 22.4}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -56,10 +41,9 @@ async def test_async_update_panelsenstemp(monkeypatch):
     assert obj.unique_id == "grenton_PAN0000"
 
 @pytest.mark.asyncio
-async def test_async_update_gate_feature(monkeypatch):
+async def test_async_update_gate_feature():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="my_feature_123", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "km/h", device_class = "wind_speed", state_class = "measurement", response_data={"status": 50.5}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="my_feature_123", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "km/h", device_class = "wind_speed", state_class = "measurement", response_data={"status": 50.5}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -72,10 +56,9 @@ async def test_async_update_gate_feature(monkeypatch):
     assert obj.unique_id == "grenton_my_feature_123"
 
 @pytest.mark.asyncio
-async def test_async_update_clu_feature(monkeypatch):
+async def test_async_update_clu_feature():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->my_feature_123", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "km/h", device_class = "wind_speed", state_class = "measurement", response_data={"status": 50.5}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->my_feature_123", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "km/h", device_class = "wind_speed", state_class = "measurement", response_data={"status": 50.5}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -88,10 +71,9 @@ async def test_async_update_clu_feature(monkeypatch):
     assert obj.unique_id == "grenton_my_feature_123"
 
 @pytest.mark.asyncio
-async def test_async_update_clu_feature_contain_obj_id(monkeypatch):
+async def test_async_update_clu_feature_contain_obj_id():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->when_DOU1234_light_up", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "%", device_class = "humidity", state_class = "measurement", response_data={"status": 100}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->when_DOU1234_light_up", grenton_type = "DEFAULT_SENSOR", unit_of_measurement = "%", device_class = "humidity", state_class = "measurement", response_data={"status": 100}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -104,10 +86,9 @@ async def test_async_update_clu_feature_contain_obj_id(monkeypatch):
     assert obj.unique_id == "grenton_when_DOU1234_light_up"
 
 @pytest.mark.asyncio
-async def test_async_update_modbus(monkeypatch):
+async def test_async_update_modbus():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS", unit_of_measurement = "kWh", device_class = "energy", state_class = "total", response_data={"status": 192349.12}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS", unit_of_measurement = "kWh", device_class = "energy", state_class = "total", response_data={"status": 192349.12}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -120,10 +101,9 @@ async def test_async_update_modbus(monkeypatch):
     assert obj.unique_id == "grenton_MOD0000"
 
 @pytest.mark.asyncio
-async def test_async_update_modbus_value(monkeypatch):
+async def test_async_update_modbus_value():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_VALUE", unit_of_measurement = "kWh", device_class = "energy", state_class = "total_increasing", response_data={"status": 0.01}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_VALUE", unit_of_measurement = "kWh", device_class = "energy", state_class = "total_increasing", response_data={"status": 0.01}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -136,10 +116,9 @@ async def test_async_update_modbus_value(monkeypatch):
     assert obj.unique_id == "grenton_MOD0000"
 
 @pytest.mark.asyncio
-async def test_async_update_modbus_rtu(monkeypatch):
+async def test_async_update_modbus_rtu():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_RTU", unit_of_measurement = "W", device_class = "power", state_class = "measurement", response_data={"status": 0.1}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_RTU", unit_of_measurement = "W", device_class = "power", state_class = "measurement", response_data={"status": 0.1}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -152,26 +131,24 @@ async def test_async_update_modbus_rtu(monkeypatch):
     assert obj.unique_id == "grenton_MOD0000"
 
 @pytest.mark.asyncio
-async def test_async_update_modbus_client(monkeypatch):
+async def test_async_update_modbus_client():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_CLIENT", unit_of_measurement = None, device_class = "ph", state_class = "measurement", response_data={"status": 192349.12}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_CLIENT", unit_of_measurement = None, device_class = "ph", state_class = "measurement", response_data={"status": 192349.12}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
         "status": "return CLU220000000:execute(0, 'MOD0000:get(19)')"
     }
     assert obj.native_value == 192349.12
-    assert obj.native_unit_of_measurement == None
+    assert obj.native_unit_of_measurement is None
     assert obj.device_class == "ph"
     assert obj.state_class == "measurement"
     assert obj.unique_id == "grenton_MOD0000"
 
 @pytest.mark.asyncio
-async def test_async_update_modbus_server(monkeypatch):
+async def test_async_update_modbus_server():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_SERVER", unit_of_measurement = "L", device_class = "water", state_class = "measurement", response_data={"status": 60}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_SERVER", unit_of_measurement = "L", device_class = "water", state_class = "measurement", response_data={"status": 60}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -184,10 +161,9 @@ async def test_async_update_modbus_server(monkeypatch):
     assert obj.unique_id == "grenton_MOD0000"
 
 @pytest.mark.asyncio
-async def test_async_update_modbus_slave_rtu(monkeypatch):
+async def test_async_update_modbus_slave_rtu():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_SLAVE_RTU", unit_of_measurement = "ppb", device_class = "volatile_organic_compounds_parts", state_class = "measurement", response_data={"status": 401.1}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->MOD0000", grenton_type = "MODBUS_SLAVE_RTU", unit_of_measurement = "ppb", device_class = "volatile_organic_compounds_parts", state_class = "measurement", response_data={"status": 401.1}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {

--- a/tests/test_switch_logic.py
+++ b/tests/test_switch_logic.py
@@ -1,51 +1,31 @@
 import pytest
 from custom_components.grenton_objects.switch import GrentonSwitch
 from homeassistant.const import STATE_ON, STATE_OFF
+from tests.helpers import MockApiClient, MockHass
 
-def create_obj(grenton_id="CLU220000000->DIN0000", response_data={"status": 1}, captured_command=None):
+
+def create_obj(grenton_id="CLU220000000->DIN0000", response_data=None, captured_command=None):
+    if response_data is None:
+        response_data = {"status": 1}
+    api_client = MockApiClient(response_data=response_data, captured_command=captured_command)
     obj = GrentonSwitch(
         api_endpoint="http://fake-api",
         grenton_id=grenton_id,
         object_name="Test Sensor",
         auto_update=False,
-        update_interval=5
+        update_interval=5,
+        api_client=api_client
     )
     obj._initialized = True
-
-    class MockLoop:
-        def time(self):
-            return 123.456
-
-    class MockHass:
-        def async_add_job(self, *args, **kwargs): pass
-        loop = MockLoop()
     obj.hass = MockHass()
     obj.async_write_ha_state = lambda: None
 
-    class FakeResponse:
-        async def json(self): return response_data
-        def raise_for_status(self): pass
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-
-    class FakeSession:
-        async def __aenter__(self): return self
-        async def __aexit__(self, *args): pass
-        def post(self, url, json):
-            captured_command["value"] = json
-            return FakeResponse()
-        def get(self, url, json):
-            if captured_command is not None:
-                captured_command["value"] = json
-            return FakeResponse()
-
-    return obj, FakeSession
+    return obj
 
 @pytest.mark.asyncio
-async def test_async_turn_on(monkeypatch):
+async def test_async_turn_on():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DOU0000", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DOU0000", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_on()
 
     assert captured_command["value"] == {
@@ -57,25 +37,23 @@ async def test_async_turn_on(monkeypatch):
     assert obj.unique_id == "grenton_DOU0000"
 
 @pytest.mark.asyncio
-async def test_async_turn_off(monkeypatch):
+async def test_async_turn_off():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DOU0000", response_data={"status": "ok"}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DOU0000", response_data={"status": "ok"}, captured_command=captured_command)
     await obj.async_turn_off()
 
     assert captured_command["value"] == {
         "command": "CLU220000000:execute(0, 'DOU0000:set(0, 0)')"
     }
     assert obj._state == STATE_OFF
-    assert not obj.is_on is True
+    assert obj.is_on is not True
     assert obj._last_command_time == 123.456
     assert obj.unique_id == "grenton_DOU0000"
 
 @pytest.mark.asyncio
-async def test_async_update(monkeypatch):
+async def test_async_update():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DOU0000", response_data={"status": 1}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DOU0000", response_data={"status": 1}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
@@ -86,15 +64,14 @@ async def test_async_update(monkeypatch):
     assert obj.unique_id == "grenton_DOU0000"
 
 @pytest.mark.asyncio
-async def test_async_update_off(monkeypatch):
+async def test_async_update_off():
     captured_command = {}
-    obj, FakeSession = create_obj(grenton_id="CLU220000000->DOU0000", response_data={"status": 0}, captured_command=captured_command)
-    monkeypatch.setattr("aiohttp.ClientSession", lambda: FakeSession())
+    obj = create_obj(grenton_id="CLU220000000->DOU0000", response_data={"status": 0}, captured_command=captured_command)
     await obj.async_update()
 
     assert captured_command["value"] == {
         "status": "return CLU220000000:execute(0, 'DOU0000:get(0)')"
     }
     assert obj._state == STATE_OFF
-    assert not obj.is_on is True
+    assert obj.is_on is not True
     assert obj.unique_id == "grenton_DOU0000"


### PR DESCRIPTION
## Summary

Refactors HTTP communication to use a shared, centralized API client with connection reuse and request batching. This allows Home Assistant group/area actions (e.g. "close all covers" or "turn off all lights in area") to be sent as a single combined request to the Grenton HTTP Gate, rather than triggering multiple individual HTTP calls. This is fully compatible with the existing Lua scripts - no changes required on the Grenton side.

## Motivation

When Home Assistant executes a group or area action, it calls each entity's service concurrently. Previously, each entity opened its own HTTP session and sent a separate request to the HTTP Gate. For large groups, this could overwhelm the Gate with simultaneous connections. The batching approach collects all concurrent commands within one event-loop tick and merges them into a single HTTP POST - leveraging the fact that the existing `HA_Integration_Script` already processes all key-value pairs from a single request body.

## Changes

### Centralized API client with command batching
- Shared `aiohttp.ClientSession` per endpoint (connection reuse, keepalive)
- Concurrent commands are merged into a single HTTP request
- Default batch window of 0 (one event-loop tick) - single commands fire instantly, only truly concurrent calls (group/area actions) get batched

### Polling mixin with command debounce
- Extracts duplicated polling lifecycle into a reusable mixin
- Ignores poll results for 2 seconds after a command to prevent stale state from overwriting optimistic UI updates

### Refactored entity platforms
- All platforms now use the shared API client and polling mixin
- Removes per-request session creation
- Uses structured logging instead of f-strings

### Entry lifecycle
- API client is cleaned up when a config entry is unloaded and no other entries share the same endpoint

### Tests
- Verifies batch merging and concurrent request handling
- Verifies poll suppression after commands
- Verifies client cleanup on entry removal
- Updated existing tests for new constructor signatures

## Testing

Manually tested on a limited set of devices: DOUT (light), and cover (roller shutter). Other device types (dimmer, LED, climate, sensors) are covered by unit tests but have not been verified on physical hardware.

## Breaking changes

None. All changes are internal - no new configuration options, services, or user-facing behavior changes. No modifications required to Grenton-side Lua scripts.